### PR TITLE
Hack to accept any vaccuum in the form of 'WORD.vacuum.*'

### DIFF
--- a/lib/connectToDevice.js
+++ b/lib/connectToDevice.js
@@ -6,6 +6,8 @@ const Device = require('./device');
 const Placeholder = require('./placeholder');
 const models = require('./models');
 
+const Vacuum = require('./devices/vacuum');
+
 module.exports = function(options) {
 	let handle = network.ref();
 
@@ -18,7 +20,13 @@ module.exports = function(options) {
 			};
 
 			// Try to resolve the correct model, otherwise use the generic device
-			const d = models[device.model];
+			let d = models[device.model];
+
+			// Hack to accept any vaccuum in the form of 'WORD.vacuum.*'
+			if(!d && device.model.match(/^\w+\.vacuum\./)) {
+				d = Vacuum;
+			}
+
 			if(! d) {
 				return new Device(deviceHandle);
 			} else {


### PR DESCRIPTION
The idea is to stop the need for updating both libraries. Just 1 😉 

Relates to https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/100